### PR TITLE
feat: Add directives for renovate to track versions

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,16 +14,20 @@ module "ssrc-jupyter-pilot" {
 
   public_key_openssh = var.public_key_openssh
 
-  z2jupyterhub_version = "3.3.8"        # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
-  k3s_version          = "v1.31.1+k3s1" # https://github.com/k3s-io/k3s/releases/
-  calico_version       = "v3.28.2"      # https://github.com/projectcalico/calico/releases
+  # renovate: datasource=github-releases depName=jupyterhub/zero-to-jupyterhub-k8s versioning=loose
+  z2jupyterhub_version = "3.3.8" # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
+  # renovate: datasource=github-releases depName=k3s-io/k3s versioning=loose
+  k3s_version = "v1.31.1+k3s1" # https://github.com/k3s-io/k3s/releases/
+  # renovate: datasource=github-releases depName=projectcalico/calico versioning=loose
+  calico_version = "v3.28.2" # https://github.com/projectcalico/calico/releases
 
   aad_client_id     = var.aad_client_id
   aad_client_secret = var.aad_client_secret
   aad_tenant_id     = var.aad_tenant_id
 
-  jupyter_image     = "jupyter/datascience-notebook"
-  jupyter_image_tag = "x86_64-ubuntu-22.04"
+  jupyter_image = "jupyter/datascience-notebook"
+  # renovate: datasource=docker depName=jupyter/datascience-notebook versioning=loose
+  jupyter_image_version = "x86_64-ubuntu-22.04"
 
   condenser_ingress_isEnabled     = true
   condenser_ingress_test_hostname = "jupyter-pilot"

--- a/terraform/modules/jupyter/README.md
+++ b/terraform/modules/jupyter/README.md
@@ -37,7 +37,7 @@ No modules.
 | <a name="input_condenser_ingress_isEnabled"></a> [condenser\_ingress\_isEnabled](#input\_condenser\_ingress\_isEnabled) | Enable web access to the server | `bool` | n/a | yes |
 | <a name="input_condenser_ingress_test_hostname"></a> [condenser\_ingress\_test\_hostname](#input\_condenser\_ingress\_test\_hostname) | Part of the URL for the web application | `string` | n/a | yes |
 | <a name="input_jupyter_image"></a> [jupyter\_image](#input\_jupyter\_image) | Name of Jupyter notebook container image (see https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html) | `string` | n/a | yes |
-| <a name="input_jupyter_image_tag"></a> [jupyter\_image\_tag](#input\_jupyter\_image\_tag) | Tag for Jupyter notebook container image | `string` | n/a | yes |
+| <a name="input_jupyter_image_version"></a> [jupyter\_image\_version](#input\_jupyter\_image\_version) | Docker tag for Jupyter notebook container image | `string` | n/a | yes |
 | <a name="input_k3s_version"></a> [k3s\_version](#input\_k3s\_version) | Version of k3s | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Name of the SSRC namespace | `string` | n/a | yes |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the SSRC network | `string` | n/a | yes |

--- a/terraform/modules/jupyter/main.tf
+++ b/terraform/modules/jupyter/main.tf
@@ -29,7 +29,7 @@ resource "harvester_cloudinit_secret" "cloud-config-jupyter" {
         aad_client_secret = var.aad_client_secret
         aad_tenant_id     = var.aad_tenant_id
         image             = var.jupyter_image
-        image_tag         = var.jupyter_image_tag
+        image_tag         = var.jupyter_image_version
       }
       )
     )

--- a/terraform/modules/jupyter/variables.tf
+++ b/terraform/modules/jupyter/variables.tf
@@ -81,7 +81,7 @@ variable "jupyter_image" {
   description = "Name of Jupyter notebook container image (see https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html)"
 }
 
-variable "jupyter_image_tag" {
+variable "jupyter_image_version" {
   type        = string
-  description = "Tag for Jupyter notebook container image"
+  description = "Docker tag for Jupyter notebook container image"
 }


### PR DESCRIPTION
That is, versions of k3s, calico, and zero-to-jupyterhub. Also trying to track a docker tag but I'm not sure it will work like this; we'll see!