### PR TITLE
feat: Provision a dev server on a small VM

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -17,6 +17,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_jupyter-dev"></a> [jupyter-dev](#module\_jupyter-dev) | ./modules/jupyter | n/a |
+| <a name="module_online-storage-dev"></a> [online-storage-dev](#module\_online-storage-dev) | ./modules/online-storage | n/a |
 | <a name="module_online-storage-pilot"></a> [online-storage-pilot](#module\_online-storage-pilot) | ./modules/online-storage | n/a |
 | <a name="module_ssrc-jupyter-pilot"></a> [ssrc-jupyter-pilot](#module\_ssrc-jupyter-pilot) | ./modules/jupyter | n/a |
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,6 +16,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_jupyter-dev"></a> [jupyter-dev](#module\_jupyter-dev) | ./modules/jupyter | n/a |
 | <a name="module_online-storage-pilot"></a> [online-storage-pilot](#module\_online-storage-pilot) | ./modules/online-storage | n/a |
 | <a name="module_ssrc-jupyter-pilot"></a> [ssrc-jupyter-pilot](#module\_ssrc-jupyter-pilot) | ./modules/jupyter | n/a |
 

--- a/terraform/dev.tf
+++ b/terraform/dev.tf
@@ -33,7 +33,7 @@ module "jupyter-dev" {
   condenser_ingress_dev_hostname = "jupyter-dev"
 }
 
-module "online-storage-pilot" {
+module "online-storage-dev" {
   source = "./modules/online-storage"
 
   namespace    = "ssrc-ns"

--- a/terraform/dev.tf
+++ b/terraform/dev.tf
@@ -1,0 +1,48 @@
+module "jupyter-dev" {
+  source = "./modules/jupyter"
+
+  vm_count = 1
+
+  vcpu       = 2
+  ram_gb     = "8Gi"
+  os_disk_gb = "50Gi"
+
+  vm_prefix = "jupyter-dev"
+
+  namespace    = "ssrc-ns"
+  network_name = "ssrc-net"
+
+  public_key_openssh = var.public_key_openssh
+
+  # renovate: datasource=github-releases depName=jupyterhub/zero-to-jupyterhub-k8s versioning=loose
+  z2jupyterhub_version = "3.3.8" # https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tags
+  # renovate: datasource=github-releases depName=k3s-io/k3s versioning=loose
+  k3s_version = "v1.31.1+k3s1" # https://github.com/k3s-io/k3s/releases/
+  # renovate: datasource=github-releases depName=projectcalico/calico versioning=loose
+  calico_version = "v3.28.2" # https://github.com/projectcalico/calico/releases
+
+  aad_client_id     = var.aad_client_id
+  aad_client_secret = var.aad_client_secret
+  aad_tenant_id     = var.aad_tenant_id
+
+  jupyter_image = "jupyter/datascience-notebook"
+  # renovate: datasource=docker depName=jupyter/datascience-notebook versioning=loose
+  jupyter_image_version = "x86_64-ubuntu-22.04"
+
+  condenser_ingress_isEnabled     = true
+  condenser_ingress_dev_hostname = "jupyter-dev"
+}
+
+module "online-storage-pilot" {
+  source = "./modules/online-storage"
+
+  namespace    = "ssrc-ns"
+  network_name = "ssrc-net"
+  vm_prefix    = "jupyter-dev-storage"
+
+  disk_settings = {
+    mountdisk1 = "10Gi"
+  }
+
+  public_key_openssh = var.public_key_openssh
+}

--- a/terraform/dev.tf
+++ b/terraform/dev.tf
@@ -30,7 +30,7 @@ module "jupyter-dev" {
   jupyter_image_version = "x86_64-ubuntu-22.04"
 
   condenser_ingress_isEnabled     = true
-  condenser_ingress_dev_hostname = "jupyter-dev"
+  condenser_ingress_test_hostname = "jupyter-dev"
 }
 
 module "online-storage-dev" {


### PR DESCRIPTION
This is a temporary measure so that we have somewhere to try risky or disruptive changes. It should be removed when we have a more intentional development environment for Condenser.

This server uses the same app registration as the pilot server; this means that anyone with access to jupyter-pilot will also be able to log in to jupyter-dev. But the computing resources are extremely limited.